### PR TITLE
add case for --DECOD and --CLAS when handling dataElements

### DIFF
--- a/model_managers/model_manager.py
+++ b/model_managers/model_manager.py
@@ -557,7 +557,16 @@ class ModelManager(NeoInterface):
                         WHEN 'USUBJID' THEN 'Subject'
                         WHEN 'STUDYID' THEN 'Study'
                     ELSE
-                        de.dataElementLabel
+                        CASE 
+                            WHEN de.dataElementName = '--DECOD' 
+                            THEN 'Dictionary-Derived Term' 
+                        ELSE 
+                            CASE 
+                                WHEN de.dataElementLabel = 'Class' 
+                                THEN de.vg  // rename label of 'Class' as causes problems in extract_class_entities() when reshaping
+                            ELSE de.dataElementLabel
+                            END
+                        END
                     END,
                 short_label: de.dataElementName,
                 create: 


### PR DESCRIPTION
@JonathanDeacon Please review when you have time! Possible wait until the cldbe PR has been merged as well.
@paltusplintus FYI
This is a mirror of the cldbe PR of similar name.
Text Copied from cldbe PR:

_When loading/reshaping the CM domain, there were some unexpected class nodes at the end of the process. This ended up being because of a data element in the CM domain having a dataElementLabel of 'Class' which cause the extract_class_entities() function in model_applier to create new nodes with the label 'Class'. This then caused problems with our URI constraints.
I have added a CASE for this to use the vg property instead of the dataElementLabel property when this occurs.__
 
_For the cdisc CM domain, the vg property is: "vg": "Interventions Observation Class Variables". If this should be handled differently, please let me know!_