### PR TITLE
update generate_query_body to allow for optional rels (with two mandatory classes)

### DIFF
--- a/query_builders/query_builder.py
+++ b/query_builders/query_builder.py
@@ -477,9 +477,9 @@ class QueryBuilder():
                 optional_rel_text_list.append(self.generate_1rel(rel))
             else:
                 rel_text_list.append(self.generate_1rel(rel))
-        q_rel_match = ''
+        q_rel_match = ',\n' if labels else ''  # if no labels then we dont want `,` before rel match in query
         if rel_text_list:
-            q_rel_match += f'\nMATCH ' + ',\n'.join(rel_text_list)
+            q_rel_match += f',\n'.join(rel_text_list)
         if optional_rel_text_list:
             q_rel_match += f'\nOPTIONAL MATCH ' + ',\n'.join(optional_rel_text_list)
         q_match += q_rel_match

--- a/query_builders/query_builder.py
+++ b/query_builders/query_builder.py
@@ -394,7 +394,31 @@ class QueryBuilder():
             df_l_rels['n_to_mand'] = df_n_to_mand
             df_l_rels = df_l_rels.sort_values(by=['optional', 'n_to_mand'], ascending=[True, False])
             g_dict = OrderedDict({0: []})
+            # ordered dict of relationships for each label e.g.
+            # OrderedDict([
+            #   (0,
+            #       [{
+            #           'Subject': [
+            #               {'from': 'Vital Signs', 'to': 'Subject', 'type': 'Subject'},
+            #               {'from': 'Subject', 'to': 'Baseline Value', 'type': 'Baseline Value'},
+            #               {...}, ...
+            #               ],
+            #           '...': [...]
+            #       }]
+            #   ),
+            #   (1,
+            #       [{
+            #           'Analysis Age': [
+            #               {'from': 'Subject', 'to': 'Analysis Age', 'type': 'Analysis Age', 'optional': 'true'}
+            #           ]
+            #       }]
+            #   )
+            # ])
+            # where 1 is optional and 0 is mandatory
             g_lookup = {}
+            # dictionary of labels
+            # e.g. {'Subject': 0, 'Analysis Age': 1}
+            # where 1 is optional and 0 is mandatory
             g = 0
             for i, row in df_l_rels.iterrows():
                 # helper list:
@@ -405,7 +429,7 @@ class QueryBuilder():
                     elif rel.get('to') in g_lookup.keys():
                         label_related_to_processed.append(rel.get('to'))
                 # processing row:
-                if not row['optional']:  # if mandatory
+                if not row['optional']:  # if mandatory on both classes and rel is not optional
                     g_dict[0].append({row['label']: row['rels']})
                     g_lookup[row['label']] = 0
                 elif row['n_to_mand'] == 0 and label_related_to_processed:  # no relationships to mandatory labels
@@ -444,9 +468,22 @@ class QueryBuilder():
     ):
         assert match in ["MATCH", "OPTIONAL MATCH"]
         q_match = f"{match} " + ",\n".join(
-            [self.generate_1match(label=label) for label in labels] +
-            [self.generate_1rel(rel) for rel in rels]
+            [self.generate_1match(label=label) for label in labels]
         )
+        rel_text_list = []
+        optional_rel_text_list = []
+        for rel in rels:
+            if rel.get('optional') == 'true':
+                optional_rel_text_list.append(self.generate_1rel(rel))
+            else:
+                rel_text_list.append(self.generate_1rel(rel))
+        q_rel_match = ''
+        if rel_text_list:
+            q_rel_match += f'\nMATCH ' + ',\n'.join(rel_text_list)
+        if optional_rel_text_list:
+            q_rel_match += f'\nOPTIONAL MATCH ' + ',\n'.join(optional_rel_text_list)
+        q_match += q_rel_match
+
         q_where = ""
         q_where_list, q_where_dict = [], {}
         q_where_rel_list, q_where_rel_dict = [], {}

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ for line in requirements:
 
 setuptools.setup(
     name="tab2neo",                           # This is the name of the package
-    version="1.1.1.1",                      # Release.Major Feature.Minor Feature.Bug Fix
+    version="1.1.1.2",                      # Release.Major Feature.Minor Feature.Bug Fix
     author="Alexey Kuznetsov",              # Full name of the author
     description="Clinical Linked Data: High-level Python classes to load, model and reshape tabular data imported into Neo4j database",
     long_description=long_description,      # Long description read from the the readme file


### PR DESCRIPTION
@paltusplintus or @JonathanDeacon Please review!

This PR is for [this PBI bugfix](https://dev.azure.com/DevOps-RD/Clinical%20Linked%20Data%20Experiments/_sprints/taskboard/Clinical%20Linked%20Data%20Experiments%20Team/Clinical%20Linked%20Data%20Experiments/Sprint%209.5?workitem=953428). I fixed the issue where if you have a relationships that has a mandatory class on either end of a relationship, the relationship would not then be counted as optional. This happens in the case in the PBI as the final relationship EX->DTC has two classes that are mandatory from the relationships defined before it. 

This update should not affect the way queries are generate already, but please check to make sure optional matches are still split out as intended!

This PR also has a [cldnb PR](https://mygithub.gsk.com/gsk-tech/cldnb/pull/298) to go along with it, but they do not depend on each other.