### PR TITLE
Feature/extend mm class functionality

### DIFF
--- a/model_managers/model_manager.py
+++ b/model_managers/model_manager.py
@@ -178,6 +178,7 @@ class ModelManager(NeoInterface):
                                 [{'prop1': 'value', 'prop2': 'value'}, ...]
         """
         assert len(props) > 0, 'Must specify at least one property to return!'
+        assert len(props) == len(set(props)), 'Specified props must not contain duplicates!'
 
         q_return = f"RETURN c.`{props[0]}` as `{props[0]}`"
         if len(props) != 1:

--- a/model_managers/model_manager.py
+++ b/model_managers/model_manager.py
@@ -169,6 +169,28 @@ class ModelManager(NeoInterface):
 
         return self.query(q)
 
+    def get_all_classes_props(self, props: [str]) -> [dict]:
+        """
+        Retrieve a list of property values for all classes.
+        :param props: List of properties ro retrieve ie ['label', ...]
+        :return: A list of dictionaries, with keys equal to the specified property name
+                            EXAMPLE, with props=['prop1', 'prop2]:
+                                [{'prop1': 'value', 'prop2': 'value'}, ...]
+        """
+        assert len(props) > 0, 'Must specify at least one property to return!'
+
+        q_return = f"RETURN c.`{props[0]}` as `{props[0]}`"
+        if len(props) != 1:
+            for prop in props[1:]:
+                q_return += f", c.`{prop}` as `{prop}`"
+
+        q = f"""
+        MATCH (c:Class)
+        {q_return}
+        """
+
+        return self.query(q)
+
     def get_rels_from_labels(self, labels: list) -> [{}]:
         """
         Returns all the relationships (according to the schema) from the nodes with specified labels

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ for line in requirements:
 
 setuptools.setup(
     name="tab2neo",                           # This is the name of the package
-    version="1.1.1.2",                      # Release.Major Feature.Minor Feature.Bug Fix
+    version="1.1.2.0",                      # Release.Major Feature.Minor Feature.Bug Fix
     author="Alexey Kuznetsov",              # Full name of the author
     description="Clinical Linked Data: High-level Python classes to load, model and reshape tabular data imported into Neo4j database",
     long_description=long_description,      # Long description read from the the readme file

--- a/tests/tests_model_manager/test_mm2.py
+++ b/tests/tests_model_manager/test_mm2.py
@@ -68,6 +68,9 @@ def test_get_all_classes_props(mm):
 
     assert short_labels == expected_short_labels
 
+    with pytest.raises(AssertionError):
+        mm.get_all_classes_props(['short_label', 'short_label'])
+
 
 def test_get_rels_btw2(mm:ModelManager):
     mm.clean_slate()

--- a/tests/tests_model_manager/test_mm2.py
+++ b/tests/tests_model_manager/test_mm2.py
@@ -54,6 +54,21 @@ def test_get_all_classes(mm):
         assert entry["Class"] in class_list
 
 
+def test_get_all_classes_props(mm):
+    mm.clean_slate()
+
+    class_list = ["A", "B", "C"]
+    mm.create_class(class_list)
+
+    for class_label in class_list:
+        mm.set_short_label(class_label, class_label.lower())
+
+    short_labels = mm.get_all_classes_props(['short_label'])
+    expected_short_labels = [{"short_label": label.lower()} for label in class_list]
+
+    assert short_labels == expected_short_labels
+
+
 def test_get_rels_btw2(mm:ModelManager):
     mm.clean_slate()
     # loading metadata (Class from json created in arrows.app)


### PR DESCRIPTION
@WillMcDGSK Please review
@paltusplintus FYI

- Added new get_all_classes_props function for retrieving specific properties for classes in neo4j.

This PR is in conjunction with the following [cldschemapi ](https://mygithub.gsk.com/gsk-tech/cldschemaapi/pull/2) and [vs-code-extension](https://mygithub.gsk.com/gsk-tech/cld-vscode-extension/pull/4) PRs