### PR TITLE
remove reference to env var

### DIFF
--- a/derivation_method/action.py
+++ b/derivation_method/action.py
@@ -1168,7 +1168,7 @@ class CallAPI(AppliesChanges):
             else:
                 raise KeyError(f"Expected property 'lang' to be 'python', 'Python', 'py', 'r' or 'R'. It was {self.meta.get('lang', '')}")
 
-            file_path = f'{self.meta.get("repo_scripts_path")}/{self.meta.get("package")}'
+            file_path = f'{self.meta.get("repo_scripts_path")}/{self.meta.get("package")}.{extension}'
 
             json_ = { 'repo': self.meta.get("github_repo"), 'branch': github_branch, 'base_url': github_base_url, 'file_path': file_path}
 

--- a/derivation_method/action.py
+++ b/derivation_method/action.py
@@ -1181,7 +1181,7 @@ class CallAPI(AppliesChanges):
             try:
                 assert commit_resp.status_code == 200, f'Status code {commit_resp.status_code}'
             except AssertionError as err:
-                logger.error(resp.get('detail'))
+                logger.error(response_content.get('detail'))
                 raise err
             else:
                 commit_id = response_content.get('commit_id')

--- a/derivation_method/action.py
+++ b/derivation_method/action.py
@@ -1156,7 +1156,7 @@ class CallAPI(AppliesChanges):
 
         # only do this if the repo exists
         if self.meta.get("github_repo") is not None:
-            token = Fernet(os.environ.get('CLDGITAPI_ENCRYPTION_KEY')).encrypt(os.getenv('GIT_TOKEN').encode())
+            token = Fernet(os.environ.get('CLDGITAPI_ENCRYPTION_KEY')).encrypt(github_token.encode())
             headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
             gitapi_url = os.getenv('CLD_GIT_API_HOST')
             endpoint = 'get_commit'

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ for line in requirements:
 
 setuptools.setup(
     name="tab2neo",                         # This is the name of the package
-    version="1.3.0.0",                      # Release.Major Feature.Minor Feature.Bug Fix
+    version="1.3.0.1",                      # Release.Major Feature.Minor Feature.Bug Fix
     author="Alexey Kuznetsov",              # Full name of the author
     description="Clinical Linked Data: High-level Python classes to load, model and reshape tabular data imported into Neo4j database",
     long_description=long_description,      # Long description read from the the readme file


### PR DESCRIPTION
@PranjaliParnerkar or @paltusplintus Please review!
@shannonhaughton @Vidhisri56 

Small fix to remove call to env var for GIT_TOKEN, when we should be using the git_token passed into the apply() method. Fixes a bug where when using MB the git token supplied on the connection tab is not used for this cldgitapi request.

Also fixed two more issues that came up:

- handling of the error when the cldgitapi returns a status != 200
- the file extension was not being sent to the gitapi correctly