### PR TITLE
Added delete_subclass method to MM and test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 All notable changes to the tab2neo package will be documented in this file.
 
+[1.3.7.1]
+
+Added delete_subclass method to delete subclass and the propagated terms and rels
+
 [1.3.6.1]
 
 Fix get_subclass() to return value as required by cld_schema_api

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ for line in requirements:
 
 setuptools.setup(
     name="tab2neo",                         # This is the name of the package
-    version="1.3.6.1",                      # Release.Major Feature.Minor Feature.Bug Fix
+    version="1.3.7.1",                      # Release.Major Feature.Minor Feature.Bug Fix
     author="Alexey Kuznetsov",              # Full name of the author
     description="Clinical Linked Data: High-level Python classes to load, model and reshape tabular data imported into Neo4j database",
     long_description="https://github.com/GSK-Biostatistics/tab2neo/blob/main/README.md",      # Long description read from the the readme file


### PR DESCRIPTION
@shannonhaughton Please review!
@paltusplintus @Vidhisri56 FYI

This PR is for this [PBI ](https://dev.azure.com/DevOps-RD/Clinical%20Linked%20Data%20Experiments/_sprints/taskboard/Clinical%20Linked%20Data%20Experiments%20Team/Clinical%20Linked%20Data%20Experiments/Sprint%2011.4?workitem=1100178)for this [task](https://dev.azure.com/DevOps-RD/Clinical%20Linked%20Data%20Experiments/_sprints/taskboard/Clinical%20Linked%20Data%20Experiments%20Team/Clinical%20Linked%20Data%20Experiments/Sprint%2011.4?workitem=1132749). 

This will allow to delete subclasses along with propagated terms to parent and propagated rels to child class. 