### PR TITLE
added method to delete derived schema fromm graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 All notable changes to the tab2neo package will be documented in this file.
 
+[1.3.8.0]
+
+Added a method in Model Manager to delete the derived schema from graph database. 
+
 [1.3.7.1]
 
 Added delete_subclass method to delete subclass and the propagated terms and rels

--- a/model_managers/model_manager.py
+++ b/model_managers/model_manager.py
@@ -1352,5 +1352,35 @@ class ModelManager(NeoInterface):
             ct,
             merge_on=['Codelist Code', 'Term Code']
         )
-    
+
+    def delete_from_graph(self):
+        actions = [
+            f"""
+            MATCH (m:Method)
+            OPTIONAL MATCH path = (m)-[r:METHOD_ACTION|NEXT*1..10]->(x:`Method`)
+            OPTIONAL MATCH path2 = (x)-[r2]->(y)
+            DETACH DELETE r2, x
+            """,
+            f"""
+            MATCH (m:Method)
+            OPTIONAL MATCH (m)-[r]-()
+            DELETE r
+            DELETE m
+            """,
+            f"""
+            MATCH (class:Class)
+            WHERE class.derived IS NOT NULL
+            OPTIONAL MATCH (class)-[r:HAS_CONTROLLED_TERM]-(term:Term)
+            OPTIONAL MATCH (class)-[r1:TO|FROM]-(rel:Relationship)-[r2:TO|FROM]-(class2:Class)
+            DELETE r, r1
+            DETACH DELETE term, class, rel
+            """,
+            f"""
+            MATCH (term1:Term)-[r:SAME_AS]->(term2:Term)
+            DELETE r
+            """
+        ]
+        for q in actions:
+            self.query(q)
+
     

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ for line in requirements:
 
 setuptools.setup(
     name="tab2neo",                         # This is the name of the package
-    version="1.3.7.1",                      # Release.Major Feature.Minor Feature.Bug Fix
+    version="1.3.8.0",                      # Release.Major Feature.Minor Feature.Bug Fix
     author="Alexey Kuznetsov",              # Full name of the author
     description="Clinical Linked Data: High-level Python classes to load, model and reshape tabular data imported into Neo4j database",
     long_description="https://github.com/GSK-Biostatistics/tab2neo/blob/main/README.md",      # Long description read from the the readme file

--- a/tests/tests_model_manager/test_mm2.py
+++ b/tests/tests_model_manager/test_mm2.py
@@ -1000,3 +1000,25 @@ def test_remove_auxilary_term_labels(mm):
     assert not set(res.get('map').get('Term 2')) ^ {'Term', 'ExtraLabel1', 'ExtraLabel'}
     assert not set(res.get('map').get('Term 3')) ^ {'Class', 'Term'}
     assert not set(res.get('map').get('Term 4')) ^ {'Class', 'Term', 'ExtraLabel1'}
+
+
+def test_delete_derived_schema_from_graph(mm):
+    mm.clean_slate()
+
+    q = """
+     MERGE(a:Class {short_label: 'A', label: 'Aardvark', `data_type`: 'string'})
+    MERGE(b:Class {short_label: 'B', label: 'Baboon', `data_type`: 'string'})
+    MERGE(c:Class {short_label: 'C', label: 'Cat', `data_type`: 'string', derived: 'true'})
+    MERGE(e:Class {short_label: 'E', label: 'Elephant', `data_type`: 'string', derived: 'true'})
+    MERGE(a)<-[:SUBCLASS_OF]-(b)
+    MERGE(b)<-[:SUBCLASS_OF]-(c)
+    MERGE(c)<-[:SUBCLASS_OF]-(e)
+    MERGE(d:Class {short_label: 'D', label: 'Dog', `data_type`: 'string', derived: 'true'})<-[:FROM]-(:Relationship {relationship_type: 'rel_3'})-[:TO]->(a)
+    """
+    mm.query(q)
+
+    mm.delete_from_graph()
+
+    q1 = """MATCH (n) RETURN (n)"""
+    res = mm.query(q1)
+    assert len(res)==2


### PR DESCRIPTION
@paltusplintus Please review.
@shannonhaughton @Vidhisri56 FYI

This PR is for this [PBI ](https://dev.azure.com/DevOps-RD/Clinical%20Linked%20Data%20Experiments/_sprints/taskboard/Clinical%20Linked%20Data%20Experiments%20Team/Clinical%20Linked%20Data%20Experiments/Sprint%2011.4?workitem=1095422)and for this [task](https://dev.azure.com/DevOps-RD/Clinical%20Linked%20Data%20Experiments/_sprints/taskboard/Clinical%20Linked%20Data%20Experiments%20Team/Clinical%20Linked%20Data%20Experiments/Sprint%2011.4?workitem=1102025).

Added a method in MM to delete the derived schema from graph database.