### PR TITLE
Feature/get data exclude label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 All notable changes to the tab2neo package will be documented in this file.
 
+[2.0.1.0]
+
+## Added
+
+- Excluded the labels marked with !! from the WITH and RETURN parts of the query generated for get_data_generic()
+
 [2.0.0.0]
 
 ## Added

--- a/model_managers/model_manager.py
+++ b/model_managers/model_manager.py
@@ -534,11 +534,13 @@ class ModelManager(NeoInterface):
         res = self.query(q, params)
         return [x['rel'] for x in res]
 
-    def infer_rels(self, labels: list, oclass_marker: str = "**", impute_relationship_type: bool = True):
+    def infer_rels(self, labels: list, labels_opt: list = None, impute_relationship_type: bool = True):
         """
         Infers most appropriate relationship type (if exists) between each pair of $labels
         for generating cypher query according to the schema
         """
+        if not labels_opt:
+            labels_opt = []  
         q = f"""
         MATCH (a:Class), (b:Class)
         WHERE a.label in $labels and b.label in $labels 
@@ -597,16 +599,15 @@ class ModelManager(NeoInterface):
         ORDER BY rel['from'], rel['to'], rel['type']        
         RETURN rel
         """
-        olabels = [label for label in labels if label.endswith(oclass_marker)]
         params = {
-            'labels': [(label[:-(len(oclass_marker))] if label in olabels else label) for label in labels],
+            'labels': labels,
             'impute_relationship_type': impute_relationship_type
         }
         res = self.query(q, params)
         rels = []
         for r in res:
             dct = r['rel']
-            if dct.get('from') in olabels or dct.get('to') in olabels:
+            if dct.get('from') in labels_opt or dct.get('to') in labels_opt:
                 dct['optional'] = True
             rels.append(dct)
         return rels

--- a/query_builders/query_builder.py
+++ b/query_builders/query_builder.py
@@ -427,7 +427,7 @@ class QueryBuilder():
                 logger.debug(f'Returning labels {labels}')
             return labels
 
-    def split_out_optional(self, labels: list, rels: list, oclass_marker: str) -> list:
+    def split_out_optional(self, labels: list, rels: list, labels_opt: list = None) -> list:
         """
         Separate labels and relationships into mandatory (0) and optional (1). Each label is returned with all the
         relationships that it is involved in.
@@ -451,7 +451,8 @@ class QueryBuilder():
         The first tuple is for mandatory labels and their rels, the second is for optional labels and their rels.
         tuple[0] is a list of labels, tuple[1] is a list of relationships.
         """
-
+        if not labels_opt:
+            labels_opt = []
         if self.verbose:
             logger.debug(f'Splitting out optional labels and rels')
             logger.debug(f'Labels {labels}')
@@ -460,8 +461,8 @@ class QueryBuilder():
         df_l_rels = pd.DataFrame(
             [
                 {
-                    'label': label[:-len(oclass_marker)] if label.endswith(oclass_marker) else label,
-                    'optional': label.endswith(oclass_marker),
+                    'label': label,
+                    'optional': (label in labels_opt),
                 } for label in labels
             ]
         )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ for line in requirements:
 
 setuptools.setup(
     name="tab2neo",                         # This is the name of the package
-    version="2.0.0.0",                      # Release.Major Feature.Minor Feature.Bug Fix
+    version="2.0.1.0",                      # Release.Major Feature.Minor Feature.Bug Fix
     author="Alexey Kuznetsov",              # Full name of the author
     description="Clinical Linked Data: High-level Python classes to load, model and reshape tabular data imported into Neo4j database",
     long_description="https://github.com/GSK-Biostatistics/tab2neo/blob/main/README.md",      # Long description read from the the readme file

--- a/tests/test_data_providers/test_dp2.py
+++ b/tests/test_data_providers/test_dp2.py
@@ -102,6 +102,31 @@ def test_get_data_generic_shortlabel_inferrels(dp):
     assert params == {'par_1': 'VISIT 1'}
 
 
+def test_get_data_generic_excllabel(dp):
+    dp.clean_slate()
+    # loading metadata (Class/Property from json created in arrows.app)
+    with open(os.path.join(filepath, 'data', 'test_get_data_generic1.json')) as jsonfile:
+        dct = json.load(jsonfile)
+    dp.load_arrows_dict(dct)
+
+    df, q, params = dp.get_data_generic(
+        labels=[f'Visit{dp.ECLASS_MARKER}', 'Visit Category'],
+        infer_rels=True,
+        where_map={'Visit': {'rdfs:label': 'VISIT 1'}},        
+        return_q_and_dict=True,
+        return_propname=False,
+        return_nodeid=False,
+        use_shortlabel=True
+    )
+    df = df[sorted(df.columns)]
+    expected_cols = ['VISITCAT']    
+    expected_df = pd.DataFrame([{'VISITCAT': 'SCHEDULED'}])
+    print(df)
+    assert df.equals(expected_df)    
+    assert q.startswith(
+        "MATCH (`VISIT`:`Visit`),\n(`VISITCAT`:`Visit Category`),\n(`VISIT`)-[`VISIT_HAS CATEGORY_VISITCAT`:`HAS CATEGORY`]->(`VISITCAT`)\nWHERE `VISIT`.`rdfs:label` = $par_1")
+    assert params == {'par_1': 'VISIT 1'}
+
 def test_get_data(dp):
     # Preparing data : create some `Class` nodes, and some "CLASS_RELATES_TO" relationships between them
     dp.clean_slate()

--- a/tests/tests_query_builders/test_qb2.py
+++ b/tests/tests_query_builders/test_qb2.py
@@ -116,7 +116,8 @@ class TestGenerateQueryBody:
 
 def test_split_out_optional(qbr: QueryBuilder):
     # #Test case #1
-    labels = ['Subject', 'Sex', 'Exposure**', 'Exposure Unit**', 'Exposure Laterality**']
+    labels = ['Subject', 'Sex', 'Exposure', 'Exposure Unit', 'Exposure Laterality']
+    labels_opt = ['Exposure', 'Exposure Unit', 'Exposure Laterality']
     rels = [
         {'from': pair[0], 'to': pair[1], 'optional': i > 0}
         for i, pair in enumerate([
@@ -128,8 +129,8 @@ def test_split_out_optional(qbr: QueryBuilder):
     ]
     res = qbr.split_out_optional(
         labels=labels,
-        rels=rels,
-        oclass_marker='**')
+        labels_opt=labels_opt,
+        rels=rels)
     # print(res)
     expected_res = [
         (
@@ -163,8 +164,8 @@ def test_split_out_optional(qbr: QueryBuilder):
     ]
     res = qbr.split_out_optional(
         labels=labels,
-        rels=rels,
-        oclass_marker='**')
+        labels_opt=labels_opt,
+        rels=rels)
     expected_res = [
         (
             ['Subject', 'Sex'],
@@ -181,7 +182,8 @@ def test_split_out_optional(qbr: QueryBuilder):
     assert res == expected_res
 
     # #Test case #3
-    labels = ['Subject', 'Sex', 'Exposure**', 'Exposure Unit**', 'Visit**', 'Vitals**', 'Vitals Unit**']
+    labels = ['Subject', 'Sex', 'Exposure', 'Exposure Unit', 'Visit', 'Vitals', 'Vitals Unit']
+    labels_opt = ['Exposure', 'Exposure Unit', 'Visit', 'Vitals', 'Vitals Unit']
     rels = [
         {'from': pair[0], 'to': pair[1], 'optional': i > 0}
         for i, pair in enumerate([
@@ -196,8 +198,8 @@ def test_split_out_optional(qbr: QueryBuilder):
     ]
     res = qbr.split_out_optional(
         labels=labels,
-        rels=rels,
-        oclass_marker='**')
+        labels_opt=labels_opt,
+        rels=rels)
     expected_res = [
         (
             ['Subject', 'Sex'],


### PR DESCRIPTION
@PranjaliParnerkar 

Please review the PR.
The change is supposed to exclude the marked with !! labels from the WITH and RETURN parts of the query generated for get_data_generic (supports Kirsten's use case).

Please check all unit tests run, including neo4cdisc and cldbe unit tests when this branch of tab2neo is used as the dependency.
And let me know if I need to fix anything

Thanks!